### PR TITLE
setup initial steps for reporting mobile releases from bitrise

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ This can be done as such:
 ### Usage
 - Add a step call within the desired workflow of your `bitrise.yml` to report the new release:
 ```yaml
-- git::https://github.com/WhoopInc/bitrise-report-release.git@main:
+- git::https://github.com/WhoopInc/bitrise-step-report-release.git@main:
      title: Send mobile release to Tombstone Service
      inputs:
-        - url: $PROD_TOMBSTONE_URL
+        - url: "$PROD_TOMBSTONE_URL"
         - version_code: "$XCODE_BUNDLE_VERSION"
         - version_name: "$XCODE_VERSION_NAME"
         - branch: "$BITRISE_GIT_BRANCH"
         # This will be the name of the app being released, either "IOS" or "Android".
         - release_name: "..."
         # This will be the type of app being released, either "IOS" or "ANDROID".
-        - mobile_platfrom: "..."
-        - auth_token: "..."
+        - mobile_platform: "..."
+        - auth_token: "$TOMBSTONE_AUTH_TOKEN"
      is_always_run: true
      is_skippable: false
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ This can be done as such:
         - branch: "$BITRISE_GIT_BRANCH"
         # This will be the name of the app being released, either "IOS" or "Android".
         - release_name: "..."
+        # This will be the type of app being released, either "IOS" or "ANDROID".
+        - mobile_platfrom: "..."
+        - auth_token: "..."
      is_always_run: true
      is_skippable: false
 ```

--- a/report.py
+++ b/report.py
@@ -1,0 +1,42 @@
+import os
+import requests
+import sys
+from datetime import datetime, timezone
+
+print("Executing report.py")
+branch = os.environ.get('branch')
+release_name = os.environ.get('release_name')
+version_name = os.environ.get('version_name')
+version_code = os.environ.get('version_code')
+mobile_platform = os.environ.get('mobile_platform')
+url = os.environ.get('url')
+auth_token = os.environ.get('auth_token')
+
+released_at = datetime.now(timezone.utc)
+released_at = released_at.strftime("%Y-%m-%dT%H:%M:%S.") + released_at.strftime("%f")[:3] + released_at.strftime("%z")
+
+payload = {
+    "release_name": release_name,
+    "version_name": version_name,
+    "version_code": version_code,
+    "branch": branch,
+    "mobile_platform": mobile_platform,
+    "hard_tombstone": False,
+    "soft_tombstone": False,
+    "locked": False,
+    "released_at": released_at
+}
+
+print('Payload: {}'.format(payload))
+
+print('Sending payload to {}'.format(url))
+request_headers = {'Authorization': auth_token}
+r = requests.post(url, json=payload, headers=request_headers)
+
+if r.status_code != 200:
+    print('Unable to send build info to {}'.format(url))
+    print('Response: {}'.format(r.text))
+    sys.exit(1)
+else:
+    print("Release successfully sent!")
+    sys.exit(0)

--- a/report.py
+++ b/report.py
@@ -13,7 +13,7 @@ url = os.environ.get('url')
 auth_token = os.environ.get('auth_token')
 
 released_at = datetime.now(timezone.utc)
-released_at = released_at.strftime("%Y-%m-%dT%H:%M:%S.") + released_at.strftime("%f")[:3] + released_at.strftime("%z")
+released_at = released_at.strftime("%Y-%m-%dT%H:%M:%S.") + released_at.strftime("%f")[:3] + '+00:00'
 
 payload = {
     "release_name": release_name,

--- a/report.py
+++ b/report.py
@@ -18,7 +18,7 @@ released_at = released_at.strftime("%Y-%m-%dT%H:%M:%S.") + released_at.strftime(
 payload = {
     "release_name": release_name,
     "version_name": version_name,
-    "version_code": version_code,
+    "version_code": int(version_code),
     "branch": branch,
     "mobile_platform": mobile_platform,
     "hard_tombstone": False,

--- a/step.sh
+++ b/step.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -exv
+
+echo 'cd-ing to step directory'
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${CURR_DIR}"
+
+echo 'installing dependencies'
+pip3 install requests
+
+echo 'executing script'
+python3 ./report.py
+
+if [ $? != 0 ];
+then
+  echo "FAILURE"
+  exit 1
+fi
+echo "SUCCESSFUL"
+exit 0

--- a/step.yml
+++ b/step.yml
@@ -1,0 +1,83 @@
+#
+# A couple of useful guides & docs:
+#
+# - Main Bitrise CLI docs: https://github.com/bitrise-io/bitrise/tree/master/_docs
+# - Step Development Guideline: https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md
+# - Bitrise.yml format spec: https://github.com/bitrise-io/bitrise/blob/master/_docs/bitrise-yml-format-spec.md
+# - Bitrise docs: http://devcenter.bitrise.io/
+# - Bitrise CLI guides: http://devcenter.bitrise.io/bitrise-cli/
+
+title: |-
+  report-release
+summary: |
+  Bitrise step that reports releases to Tombstone Service 
+description: |
+  Reports release info to PROD tombstone-service. (Dev releases are handled by the deploy WBL)
+website: https://github.com/WhoopInc/bitrise-report-release
+source_code_url: https://github.com/WhoopInc/bitrise-report-release
+support_url: https://github.com/WhoopInc/bitrise-report-release/issues
+project_type_tags:
+  - android
+  - ios
+
+type_tags:
+  - utility
+
+is_requires_admin_user: false
+is_always_run: true
+is_skippable: true
+
+toolkit:
+  bash:
+    entry_file: step.sh
+
+inputs:
+  - url:
+    opts:
+      title: "Tombston Service API endpoint"
+      summary: |-
+        Specifies the endpoint to send the Bitrise release info to
+      is_required: true
+  - branch: $BITRISE_GIT_BRANCH
+    opts:
+      title: "Branch name"
+      summary: |-
+        The Github branch associated with the build
+      is_expand: true
+      is_required: true
+  - auth_token: $TOMBSTONE_AUTH_TOKEN
+    opts:
+      title: "Tombstone Service auth token"
+      summary: |-
+        Authentication token used in POST request to authenticate with the Tombstone Service API
+      sensitive: true
+      is_expand: true
+      is_required: true
+  - version_code:
+    opts:
+      title: "Version Code"
+      summary: |-
+        The internal code of the version associated with the completed build
+      is_expand: true
+      is_required: true
+  - version_name:
+    opts:
+      title: "Version Name"
+      summary: |-
+        The external name of the version associated with the completed build
+      is_expand: true
+      is_required: true
+  - release_name:
+    opts:
+      title: "Release Name"
+      summary: |-
+        The name of the release being reported
+      is_expand: true
+      is_required: true
+  - mobile_platform:
+    opts:
+      title: "Mobile Platform"
+      summary: |-
+        The platform for the release. Either IOS or ANDROID.
+      is_expand: true
+      is_required: true

--- a/step.yml
+++ b/step.yml
@@ -53,14 +53,14 @@ inputs:
       sensitive: true
       is_expand: true
       is_required: true
-  - version_code:
+  - version_code: "$XCODE_BUNDLE_VERSION"
     opts:
       title: "Version Code"
       summary: |-
         The internal code of the version associated with the completed build
       is_expand: true
       is_required: true
-  - version_name:
+  - version_name: "$XCODE_VERSION_NAME"
     opts:
       title: "Version Name"
       summary: |-

--- a/step.yml
+++ b/step.yml
@@ -13,9 +13,9 @@ summary: |
   Bitrise step that reports releases to Tombstone Service 
 description: |
   Reports release info to PROD tombstone-service. (Dev releases are handled by the deploy WBL)
-website: https://github.com/WhoopInc/bitrise-report-release
-source_code_url: https://github.com/WhoopInc/bitrise-report-release
-support_url: https://github.com/WhoopInc/bitrise-report-release/issues
+website: https://github.com/WhoopInc/bitrise-step-report-release
+source_code_url: https://github.com/WhoopInc/bitrise-step-report-release
+support_url: https://github.com/WhoopInc/bitrise-step-report-release/issues
 project_type_tags:
   - android
   - ios


### PR DESCRIPTION
Currently, we are only reporting dev releases to Tombstone Service. To have visibility into our production releases, this step is needed to send release information to Tombstone Service. This step will be leveraged by both the android and ios Bitrise build yamls.